### PR TITLE
replaced body styles with #bootcards

### DIFF
--- a/src/css/bootcards-android.scss
+++ b/src/css/bootcards-android.scss
@@ -1,13 +1,15 @@
 @import "bootcards-mobile-shared.scss";
 
-body {
+#bootcards {
 	background-color: #eee;
 	font-family:"Roboto",sans-serif;
 }
 
-h1, h2, h3, h4, h5, h6 {
-	font-weight: normal;
-	font-family:"Roboto",sans-serif;
+#bootcards {
+	h1, h2, h3, h4, h5, h6 {
+		font-weight: normal;
+		font-family:"Roboto",sans-serif;
+	}
 }
 
 /* OFFCANVAS LIST FOR TABLET PORTRAIT MODE */

--- a/src/css/bootcards-desktop.scss
+++ b/src/css/bootcards-desktop.scss
@@ -1,6 +1,6 @@
 @import "bootcards.scss";
 
-body {
+#bootcards {
 	padding-top: 80px;
 	background: #f5f5f5;
 }

--- a/src/css/bootcards-ios.scss
+++ b/src/css/bootcards-ios.scss
@@ -5,14 +5,14 @@ $navbar-height-phone-landscape: 32px;
 $footer-height: 50px;
 $footer-height-phone-landscape: 44px;
 
-html, body {
+html, #bootcards {
   height: 100%;
   /*overflow-y: scroll;*/
   overflow-y: hidden;
   -webkit-overflow-scrolling: touch;
 }
 
-body {
+#bootcards {
 	background-color: #efeff4;
 	font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 	padding-top: $navbar-height;

--- a/src/css/bootcards-mobile-shared.scss
+++ b/src/css/bootcards-mobile-shared.scss
@@ -1,11 +1,11 @@
 @import "bootcards.scss";
 
-html, 
-body {
+html,
+#bootcards {
 	height: 100%;
 }
 
-body {
+#bootcards {
 	padding-top: 50px;
 	overflow-x:hidden;
 }
@@ -19,8 +19,10 @@ body {
 }
 
 
-small {
-	font-size: 70%;
+#bootcards {
+	small {
+		font-size: 70%;
+	}
 }
 
 


### PR DESCRIPTION
Hey bootcards,

Love the project. IMO the changes to native elements (body, headers) padding and background color make assumptions about how the entire site should look which may be incorrect (as it is for me). I understand how it affects http://demo.bootcards.org/ and I think it looks nice for that use case.

I replaced the body styles with a `#bootcards` id wrapper to maintain the current styles. Obviously this can be changed, or you might want to remove the base styles all together.

What do you think?

Thanks!